### PR TITLE
Ajout de la longitude et de la tatitude au model de Zone. Permet de p…

### DIFF
--- a/app/controllers/zones_controller.rb
+++ b/app/controllers/zones_controller.rb
@@ -1,0 +1,13 @@
+class ZonesController < ApplicationController
+
+  def update
+    Zone.all.each do |zone|
+      zone.latitude.nil?
+        zone.latitude = zone.points.first.lat
+      zone.longitude.nil?
+        zone.longitude = zone.points.first.lng
+      zone.save!
+    end
+  end
+
+end

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -15,7 +15,9 @@ class Booking < ApplicationRecord
   end
 
   def self.incoming user
-    for_me(user).to_come.ending_soon
+    for_me(user)
+      .to_come
+      .ending_soon
   end
 
 end

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -1,4 +1,5 @@
 class Zone < ApplicationRecord
   belongs_to :town
   has_many :points
+  geocoded_by :address, :latitude  => :latitude, :longitude => :longitude # ActiveRecord
 end

--- a/db/migrate/20170918124538_add_coordinates_to_zones.rb
+++ b/db/migrate/20170918124538_add_coordinates_to_zones.rb
@@ -1,0 +1,6 @@
+class AddCoordinatesToZones < ActiveRecord::Migration[5.1]
+  def change
+    add_column :zones, :latitude, :float
+    add_column :zones, :longitude, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170915102318) do
+ActiveRecord::Schema.define(version: 20170918124538) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -96,6 +96,8 @@ ActiveRecord::Schema.define(version: 20170915102318) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "id_zone"
+    t.float "latitude"
+    t.float "longitude"
     t.index ["town_id"], name: "index_zones_on_town_id"
   end
 


### PR DESCRIPTION
…ouvoir appeler la méthode .near de geocoder sur les zones et ainsi de n'appeler que les zones à proximité de la zone qui intéresse le client.